### PR TITLE
NSP-608: Include BCP(with ETA) details for GB/XI Arrivals/departures …

### DIFF
--- a/app/views/helpers/BCPTimelineSnippet.scala.html
+++ b/app/views/helpers/BCPTimelineSnippet.scala.html
@@ -28,8 +28,13 @@
             @messages("service.availability.bcp.invoked.p1")
             <a href=@appConfig.govUKTransitManualLink>@messages("service.availability.issues.p5")</a>.
         </p>
-        @if(bcp.eta.isEmpty){
-            <p class="govuk-body">@messages("service.availability.bcp.invoked.eta.unknown")</p>
+        <p class="govuk-body">
+        @{bcp.eta.fold(
+            {messages("service.availability.bcp.invoked.eta.unknown")}
+            ) { eta =>
+                {messages("service.availability.bcp.invoked.eta.known", bcp.channel.caption, eta)}
+            }
         }
+        </p>
     </div>
 </li>

--- a/app/views/helpers/TimelineOfKnownIssues.scala.html
+++ b/app/views/helpers/TimelineOfKnownIssues.scala.html
@@ -59,6 +59,8 @@
                             {messages("service.availability.eta.estimate")}
                             {ch.channel.displayName}
                             {messages("service.availability.eta.availability")} {eta}.
+                        </p>
+                        <p class="govuk-body">
                             {if(ch.channel.isGbOrXi){
                                 {messages("service.availability.eta.notify.component")}
                             } else {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -121,6 +121,7 @@ service.availability.help.with.channels.p4=The Push Pull Notification Service (P
 service.availability.bcp.invoked=Business Continuity Procedure invoked
 service.availability.bcp.invoked.p1=The Business Continuity Procedure has been invoked by HMRC. Information on the Business Continuity Procedure can be found in the
 service.availability.bcp.invoked.eta.unknown=We will notify you here and HMRC will advise you by email when the system core is available. We will notify you here once an estimated time of availability is known.
+service.availability.bcp.invoked.eta.known=We will notify you here and HMRC will advise you by email when the system core is available. We estimate the {0} system core to be available at {1}.
 
 planned-downtime.title=Planned downtime
 planned-downtime.heading=Planned downtime


### PR DESCRIPTION
…in the Timeline view

**Arrivals**
![image](https://user-images.githubusercontent.com/98329769/164271472-196f46ee-c597-4cf4-b4d2-5b0f96f539f0.png)

**Departures**
![image](https://user-images.githubusercontent.com/98329769/164271608-6d88e809-f44e-4f37-9652-77b973439487.png)
